### PR TITLE
Fixes the filter form fired on enter-key in create new form

### DIFF
--- a/fme-alfresco-extdl-share/src/main/resources/META-INF/components/data-lists/extended-datagrid.js
+++ b/fme-alfresco-extdl-share/src/main/resources/META-INF/components/data-lists/extended-datagrid.js
@@ -1,4 +1,3 @@
-
 (function()
 {
    /**
@@ -485,7 +484,7 @@
            });
     	  var data =
           {
-             htmlid: this.id
+             htmlid: this.id + "-extDgFilterForm"
           };
     	  
     	  Alfresco.util.Ajax.request(
@@ -662,6 +661,13 @@
     	 {
     		 var event = keyEvent[1],
     		 target = event.target ? event.target : event.srcElement;
+    		 
+    		 var targetId = target.id;
+    		 if (!(targetId.contains(me.id) && targetId.contains("-extDgFilterForm")))
+    		 {
+    		 	 //this is not from filterForm
+    		 	 return false;
+    		 }
     		 
     		 if (target.tagName == "TEXTAREA")
     		 {


### PR DESCRIPTION
If you use enter-key in the Create new row form (toolbar), the filterform receives this event also and updates. I my case this cleared the content of the list.
